### PR TITLE
Major syntax highlight update

### DIFF
--- a/syntax/sentinel.vim
+++ b/syntax/sentinel.vim
@@ -1,58 +1,93 @@
-syntax keyword sentinelKeywords
-  \ rule
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" standard keywords for literals, etc
+syntax keyword sentinelkeywords
   \ as
-  \ if
+  \ default
   \ func
+  \ rule
   \ return
-  \ for
-  \ keys
-  \ values
-  \ range
-  \ delete
+  \ break
+  \ continue
+
+" standard keywords as matches (have other forms)
+syntax match sentinelKeywords 
+  \ "when"
+
+highlight default link sentinelKeywords Keyword
+
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" builtins
+syntax keyword sentinelBuiltins
   \ append
-  \ main
+  \ delete
+  \ error
+  \ keys
+  \ length
+  \ print
+  \ range
+  \ values
+  \ int
+  \ float
+  \ string
+  \ bool
 
-syntax keyword sentImport import
+highlight default link sentinelBuiltins Identifier
 
-syntax match sentinelOperators "\v\="
-syntax match sentinelOperators "\v\+"
-syntax match sentinelOperators "\v-"
-syntax match sentinelOperators "\v\*"
-syntax match sentinelOperators "\v\/"
-syntax match sentinelOperators "\v\%"
-syntax match sentinelOperators "\v!"
-syntax match sentinelOperators "\v<"
-syntax match sentinelOperators "\v,"
-syntax match sentinelOperators "\v\."
-syntax match sentinelOperators "\v:"
-syntax match sentinelOperators "\v;"
-syntax match sentinelOperators "\v\=\="
-syntax match sentinelOperators "\v\+\="
-syntax match sentinelOperators "\v-\="
-syntax match sentinelOperators "\v\*\="
-syntax match sentinelOperators "\v/\="
-syntax match sentinelOperators "\v\%\="
-syntax match sentinelOperators "\v\\>"
-syntax match sentinelOperators "\v!\="
-syntax match sentinelOperators "\v<\="
-syntax match sentinelOperators "\v>\="
-syntax match sentinelOperators "\v\{"
-syntax match sentinelOperators "\v\}"
-syntax match sentinelOperators "\v\("
-syntax match sentinelOperators "\v\)"
-syntax match sentinelOperators "\v\["
-syntax match sentinelOperators "\v\]"
-syntax match sentinelOperators "\v\band\s"
-syntax match sentinelOperators "\v\bor\s"
-syntax match sentinelOperators "\vcontains\s"
-syntax match sentinelOperators "\vin\s"
-syntax match sentinelOperators "\v\bin\s"
-syntax match sentinelOperators "\v\bis\s"
-syntax match sentinelOperators "\v\bmatches\s"
-syntax match sentinelOperators "\v\bnot\s"
-syntax match sentinelOperators "\v\bxor\s"
-syntax match sentinelOperators "\v\belse\s"
 
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" booleans and other pre-declared identifiers
+syntax keyword sentinelBooleans true false
+syntax keyword sentinelPreDecl  null undefined
+
+highlight default link sentinelBooleans Boolean
+highlight default link sentinelPreDecl  sentinelBooleans
+
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" conditional keywords
+syntax keyword sentinelConditionals
+  \ if
+  \ case
+
+" conditional pattern - else
+syntax match sentinelConditionals "else\ze\s\+\(if\s+\)\?.*{"
+
+highlight default link sentinelConditionals Conditional
+
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" loops (non-expression/quant)
+syntax keyword sentinelLoop 
+  \ for
+  \ any
+  \ all
+
+highlight default link sentinelLoop Repeat
+
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" imports
+syntax keyword sentinelImport import
+highlight default link sentinelImport Include
+
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" parameters
+syntax keyword sentinelParam param
+highlight default link sentinelParam Define
+
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" Labels
+syntax match sentinelLabels "else\ze\s*:"
+syntax match sentinelLabels "when\ze\s\+.*:"
+
+highlight default link sentinelLabels Label
+
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" Numbers
 syntax match sentinelNumber "\v<\d+>"
 syntax match sentinelNumber "\v<\d+\.\d+>"
 syntax match sentinelNumber "\v<\d*\.?\d+([Ee]-?)?\d+>"
@@ -60,15 +95,18 @@ syntax match sentinelNumber "\v<0x\x+([Pp]-?)?\x+>"
 syntax match sentinelNumber "\v<0b[01]+>"
 syntax match sentinelNumber "\v<0o\o+>"
 
-" Comments
-syntax match sentinelComment "\v(#|//).*"
-
-syntax region sentinelString start=/"/ skip=/\\"/ end=/"/ oneline
-
-" Set highlights
-highlight default link sentinelKeywords Keyword
-highlight default link sentinelString String
 highlight default link sentinelNumber Number
-highlight default link sentinelOperators Operator
+
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" Strings
+syntax region sentinelString start=/"/ skip=/\\"/ end=/"/ oneline contains=@Spell
+
+highlight default link sentinelString String
+
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" Comments
+syntax match sentinelComment "\v(#|//).*" contains=@Spell
+
 highlight default link sentinelComment Comment
-highlight default link sentImport Include


### PR DESCRIPTION
This makes some major changes to the syntax highlighting, adding
keywords, correcting some syntax class discrepancies, adding some
handling for labels, builtins, and other pre-declared identifiers, and
removes operators.

Operator removal is following a precedent in vim-go, where this is a
toggle - rather than having that setting for now, I've just removed it.
It can be re-added and put behind a toggle if need be.