### PR TITLE
Display fmt errors on save

### DIFF
--- a/ftplugin/sentinel.vim
+++ b/ftplugin/sentinel.vim
@@ -46,7 +46,14 @@ function! sentinel#Fmt()
 
   " Run sentinel format
   let command = "sentinel fmt " . l:tmpname
-  call sentinel#System(command)
+  let l:errmsg = sentinel#System(command)
+
+  " Is there an error?
+  if v:shell_error != 0
+    echohl ErrorMsg
+    echo l:errmsg
+    echohl None
+  endif
 
   " remove undo point caused via BufWritePre
   try | silent undojoin | catch | endtry


### PR DESCRIPTION
Currently, "sentinel fmt" on save fails silently, this just adds some
basic messaging when there is an error so you know that there is
actually one. We will want to fix this to some better syntax checking
and general policy verification when we have it.

Note that this currently will display ANSI escape characters in the
output, a further release of Sentinel should keep this from happening by
disabling color when there isn't a TTY.